### PR TITLE
ADD: folder preset edit page

### DIFF
--- a/src/main/exec/folderPreset.ts
+++ b/src/main/exec/folderPreset.ts
@@ -1,0 +1,33 @@
+import { eq } from "drizzle-orm";
+import { folderPresetTable } from "../schema/v1.0.0";
+import { db } from "../storage";
+import { mkdirSync } from "fs";
+import { join } from "path";
+
+/**
+ * 폴더프리셋을 적용한다.
+ * @author 오지민
+ */
+export async function applyFolderPreset(folderPresetId: string, path: string) {
+  const raw = await db
+    .select()
+    .from(folderPresetTable)
+    .where(eq(folderPresetTable.id, folderPresetId))
+    .limit(1);
+
+  const result = raw[0];
+  if (!result) return;
+
+  const { name } = result;
+  const folderPath = join(path, name);
+  mkdirSync(folderPath);
+
+  const raw2 = await db
+    .select()
+    .from(folderPresetTable)
+    .where(eq(folderPresetTable.parentId, folderPresetId));
+
+  for (const child of raw2) {
+    await applyFolderPreset(child.id, folderPath);
+  }
+}

--- a/src/main/schema/v1.0.0.ts
+++ b/src/main/schema/v1.0.0.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { AnySQLiteColumn, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { InferSelectModel } from "drizzle-orm/table";
 import { app } from "electron";
 import { v4 as uuid } from "uuid";
@@ -134,10 +134,13 @@ export const folderPresetTable = sqliteTable("folder_preset", {
   description: text("description", { mode: "text" })
     .$defaultFn(() => "this is folder desciption.")
     .notNull(),
-  parentId: text("parentId", { mode: "text" }).references(() => folderPresetTable.id, {
-    onDelete: "cascade",
-    onUpdate: "cascade"
-  })
+  parentId: text("parentId", { mode: "text" }).references(
+    (): AnySQLiteColumn => folderPresetTable.id,
+    {
+      onDelete: "cascade",
+      onUpdate: "cascade"
+    }
+  )
 });
 
 // Type ------------------------------------------------------------

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -10,7 +10,11 @@ export function registIpcs(ipcDef: IpcDef) {
         const result = await ipcDef[channel](...args);
         return [true, result];
       } catch (error: any) {
-        return [false, { ...error }];
+        if (error instanceof Error) {
+          return [false, { name: error.name, message: error.message }];
+        } else {
+          return [false, { ...error }];
+        }
       }
     });
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,7 @@ export const api = createApiSelector<typeof ipcApiDef>()({
   getFolderPreset: true,
   updateFolderPreset: true,
   deleteFolderPreset: true,
+  applyFolderPreset: true,
   // window ----------------
   closeSelf: true,
   minimizeSelf: true,

--- a/src/preload/utils.ts
+++ b/src/preload/utils.ts
@@ -19,8 +19,6 @@ export function createApiSelector<TDef extends IpcDef>() {
             const error = new Error();
             error.name = resultOrError.name;
             error.message = resultOrError.message;
-            error.cause = resultOrError.cause;
-            error.stack = resultOrError.stack;
             throw error;
           }
         };

--- a/src/renderer/components/ui/toaster.tsx
+++ b/src/renderer/components/ui/toaster.tsx
@@ -17,7 +17,11 @@ export function Toaster() {
           <Toast key={id} {...props}>
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
-              {description && <ToastDescription>{description}</ToastDescription>}
+              {description && (
+                <ToastDescription className="whitespace-nowrap overflow-hidden text-ellipsis">
+                  {description}
+                </ToastDescription>
+              )}
             </div>
             {action}
             {/* <ToastClose /> */}

--- a/src/renderer/routes/folder-presets/$folderPresetId/-FolderUnit.tsx
+++ b/src/renderer/routes/folder-presets/$folderPresetId/-FolderUnit.tsx
@@ -1,0 +1,143 @@
+import {
+  useCreateFolderPreset,
+  useDeleteFolderPreset,
+  useFolderPreset,
+  useUpdateFolderPreset
+} from "@renderer/api/folderPresets";
+import { Button } from "@renderer/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from "@renderer/components/ui/context-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle
+} from "@renderer/components/ui/dialog";
+import { Input } from "@renderer/components/ui/input";
+import { useToastWithDismiss } from "@renderer/hooks/useToastWithDismiss";
+import { cn } from "@renderer/lib/utils";
+import { ChevronRight, Folder, FolderOpen } from "lucide-react";
+import { useState } from "react";
+
+type Props = {
+  folderPresetId: string;
+  depts: number;
+};
+
+type NormalKey = "name" | "description";
+
+export function FolderUnit(props: Props) {
+  const { folderPresetId, depts } = props;
+
+  const [open, setOpen] = useState(false);
+  const [edit, setEdit] = useState(false);
+  const { toast } = useToastWithDismiss();
+  const { data: folderPreset } = useFolderPreset(folderPresetId);
+  const createFolderPreset = useCreateFolderPreset(folderPresetId);
+  const updateFolderPreset = useUpdateFolderPreset(folderPresetId);
+  const deleteFolderPreset = useDeleteFolderPreset(folderPreset.parentId, folderPresetId);
+
+  const onModifyBlur = (key: NormalKey) => async (e: React.FocusEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === folderPreset[key]) return;
+    await updateFolderPreset.mutateAsync({
+      data: { [key]: value },
+      onError: (error) => {
+        console.log(error);
+        toast(error.name, error.message);
+        e.target.value = folderPreset[key];
+      }
+    });
+  };
+
+  const onCreateFolderPresetClick = async () => {
+    await createFolderPreset.mutateAsync({
+      onError: (error) => {
+        toast(error.name, error.message);
+      },
+      onSuccess: () => {
+        setOpen(true);
+      }
+    });
+  };
+
+  const onDeleteFolderPresetClick = async () => {
+    await deleteFolderPreset.mutateAsync({
+      onError: (error) => {
+        toast(error.name, error.message);
+      }
+    });
+  };
+
+  const onButtonKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "F2") {
+      if (folderPreset.parentId !== null) {
+        e.preventDefault();
+        setEdit(true);
+        return;
+      }
+    }
+
+    if (e.key === "ArrowRight") {
+      setOpen(true);
+      return;
+    }
+    if (e.key === "ArrowLeft") {
+      setOpen(false);
+      return;
+    }
+  };
+
+  return (
+    <div>
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <Button
+            variant="ghost"
+            className="py-0 font-normal rounded-none min-w-full justify-start focus:bg-secondary focus:outline-none focus:border-none items-center h-8"
+            style={{ paddingLeft: `${depts}rem` }}
+            onClick={() => setOpen((prev) => !prev)}
+            onKeyDown={onButtonKeyDown}
+          >
+            <ChevronRight className={cn("w-4 h-4 transition-all", { "rotate-90": open })} />
+            &nbsp;
+            {open ? <FolderOpen className="w-4 h-4" /> : <Folder className="w-4 h-4" />}
+            &nbsp;&nbsp;
+            <span>{folderPreset.name}</span>
+          </Button>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-56">
+          {folderPreset.parentId !== null ? (
+            <ContextMenuItem onClick={() => setEdit(true)}>이름 바꾸기</ContextMenuItem>
+          ) : null}
+          <ContextMenuItem onClick={onCreateFolderPresetClick}>새로운 폴더</ContextMenuItem>
+          {folderPreset.parentId !== null ? (
+            <ContextMenuItem onClick={onDeleteFolderPresetClick}>삭제하기</ContextMenuItem>
+          ) : null}
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <Dialog open={edit} onOpenChange={setEdit}>
+        <DialogTitle>
+          <DialogDescription></DialogDescription>
+        </DialogTitle>
+        <DialogContent
+          className="w-64 bg-transparent border-none outline-none p-0"
+          hideDefaultClose
+        >
+          <Input id="name" defaultValue={folderPreset.name} onBlur={onModifyBlur("name")} />
+        </DialogContent>
+      </Dialog>
+
+      <div className={cn("", { hidden: !open })}>
+        {folderPreset.children?.map((id) => (
+          <FolderUnit key={id} folderPresetId={id} depts={depts + 1} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/routes/folder-presets/$folderPresetId/index.tsx
+++ b/src/renderer/routes/folder-presets/$folderPresetId/index.tsx
@@ -1,9 +1,113 @@
-import { createFileRoute } from "@tanstack/react-router";
+import {
+  useApplyFolderPreset,
+  useDeleteFolderPreset,
+  useFolderPreset,
+  useUpdateFolderPreset
+} from "@renderer/api/folderPresets";
+import { Button } from "@renderer/components/ui/button";
+import { Card } from "@renderer/components/ui/card";
+import { Input } from "@renderer/components/ui/input";
+import { Label } from "@renderer/components/ui/label";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { ArrowRight, Trash2Icon } from "lucide-react";
+import { FolderUnit } from "./-FolderUnit";
+import { useToastWithDismiss } from "@renderer/hooks/useToastWithDismiss";
 
 export const Route = createFileRoute("/folder-presets/$folderPresetId/")({
   component: Page
 });
 
+type NormalKey = "name" | "description";
+
 function Page() {
-  return <div></div>;
+  const { folderPresetId } = Route.useParams();
+
+  const router = useRouter();
+  const { toast } = useToastWithDismiss();
+  const { data: folderPreset } = useFolderPreset(folderPresetId);
+  const deleteFolderPreset = useDeleteFolderPreset(null, folderPresetId);
+  const updateFolderPreset = useUpdateFolderPreset(folderPresetId);
+  const applyFolderPreset = useApplyFolderPreset(folderPresetId);
+
+  const onModifyBlur = (key: NormalKey) => async (e: React.FocusEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === folderPreset[key]) return;
+    await updateFolderPreset.mutateAsync({
+      data: { [key]: value },
+      onError: (error) => {
+        toast(error.name, error.message);
+        e.target.value = folderPreset[key];
+      }
+    });
+  };
+
+  const onApplyClick = async () => {
+    await applyFolderPreset.mutateAsync({
+      onError: (error) => {
+        toast(error.name, error.message);
+      },
+      onSuccess: () => {
+        toast("적용 완료", "폴더 프리셋이 적용되었습니다.");
+      }
+    });
+  };
+
+  const onDeleteClick = () => {
+    deleteFolderPreset.mutate({
+      onError: (error) => {
+        toast(error.name, error.message);
+      }
+    });
+    router.history.back();
+  };
+
+  return (
+    <main className="w-full mb-2 space-y-2">
+      <Card className="w-96 shadow-none mx-2">
+        <ul className="m-4 space-y-2">
+          <li className="flex items-center">
+            <Label htmlFor="name" className="flex-1">
+              이름
+            </Label>
+            <Input
+              id="name"
+              className="bg-secondary border-none w-56"
+              size="sm"
+              name="name"
+              defaultValue={folderPreset.name}
+              onBlur={onModifyBlur("name")}
+            />
+          </li>
+          <li className="flex items-center">
+            <Label htmlFor="description" className="flex-1">
+              설명
+            </Label>
+            <Input
+              id="description"
+              className="bg-secondary border-none w-56"
+              size="sm"
+              name="description"
+              defaultValue={folderPreset.description}
+              onBlur={onModifyBlur("description")}
+            />
+          </li>
+          <li className="flex items-center">
+            <Label className="flex-1">적용하기</Label>
+            <Button className="w-56" variant="secondary" size="sm" onClick={onApplyClick}>
+              <ArrowRight className="w-5 h-5" />
+            </Button>
+          </li>
+          <li className="flex items-center">
+            <Label className="flex-1">삭제하기</Label>
+            <Button className="w-56" variant="secondary" size="sm" onClick={onDeleteClick}>
+              <Trash2Icon className="w-5 h-5" />
+            </Button>
+          </li>
+        </ul>
+      </Card>
+      <div className="w-full overflow-x-scroll">
+        <FolderUnit folderPresetId={folderPresetId} depts={1} />
+      </div>
+    </main>
+  );
 }

--- a/src/renderer/routes/folder-presets/index.tsx
+++ b/src/renderer/routes/folder-presets/index.tsx
@@ -1,4 +1,4 @@
-import { useCreateFolderPreset, useFolderPresets } from "@renderer/api/folderPresets";
+import { useCreateFolderPreset, useRootFolderPresets } from "@renderer/api/folderPresets";
 import { Button } from "@renderer/components/ui/button";
 import { Skeleton } from "@renderer/components/ui/skeleton";
 import { useToastWithDismiss } from "@renderer/hooks/useToastWithDismiss";
@@ -14,11 +14,11 @@ export const Route = createFileRoute("/folder-presets/")({
 
 export function Page() {
   const { toast } = useToastWithDismiss();
-  const { data: folderPresets } = useFolderPresets(null);
-  const create = useCreateFolderPreset();
+  const { data: folderPresets } = useRootFolderPresets();
+  const createFolderPreset = useCreateFolderPreset(null);
 
   const onCreateClick = async (_: React.MouseEvent<HTMLButtonElement>) => {
-    await create.mutateAsync({
+    await createFolderPreset.mutateAsync({
       onError: (error) => {
         toast(error.name, error.message);
       }
@@ -34,7 +34,7 @@ export function Page() {
           </Link>
         </Button>
       ))}
-      {create.isPending ? ( //
+      {createFolderPreset.isPending ? ( //
         <motion.div
           initial={{ scale: 0.3 }}
           animate={{ scale: 1 }}


### PR DESCRIPTION
### 폴더 프리셋 상세페이지 추가

1. 폴더 프리셋을 구조를 설정할 수 있도록 수정
2. 폴더 프리셋을 적용할 때, 같은 이름의 폴더가 존재할 경우, 에러를 표시하도록 함
3. 폴더 프리셋을 설정할 때, 같은 부모폴더를 공유하는 2개의 폴더가 같은 이름일 수 없도록 함
4. 폴더들은 모두 우클릭 메뉴가 있음
5. 폴더를 F2로 이름변경이 가능함 (우클릭메뉴에서 이름 바꾸기를 눌러서도 가능함)
6. Tab을 사용해서 다음 폴더로 이동이 가능함.
7. Shift + Tab을 사용해서 이전 폴더로 이동이 가능함
8. 폴더가 선택된 상태에서 <-, -> 방향키를 사용해서 하위폴더를 펼치고 접을 수 있음